### PR TITLE
Issue/php 8 compatibility

### DIFF
--- a/Standards/FuelPHP/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/Standards/FuelPHP/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -25,7 +25,12 @@
  * @version   Release: 1.4.0
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class FuelPHP_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_Sniff
+namespace FuelPHP\Sniffs\Arrays;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class ArrayDeclarationSniff implements Sniff
 {
 
 
@@ -69,7 +74,7 @@ class FuelPHP_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_Sni
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Standards/FuelPHP/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/Standards/FuelPHP/Sniffs/Classes/ClassDeclarationSniff.php
@@ -12,11 +12,6 @@
  * @license   http://opensource.org/licenses/MIT MIT License
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-if (class_exists('PEAR_Sniffs_Classes_ClassDeclarationSniff', true) === false) {
-    throw new PHP_CodeSniffer_Exception(
-        'Class PEAR_Sniffs_Classes_ClassDeclarationSniff not found'
-    );
-}
 
 /**
  * FuelPHP_Sniffs_Classes_ClassDeclarationSniff
@@ -31,7 +26,14 @@ if (class_exists('PEAR_Sniffs_Classes_ClassDeclarationSniff', true) === false) {
  * @version   Release: 1.0.0
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class FuelPHP_Sniffs_Classes_ClassDeclarationSniff extends PEAR_Sniffs_Classes_ClassDeclarationSniff
+
+namespace FuelPHP\Sniffs\Classes;
+
+use PHP_CodeSniffer\Standards\PEAR\Sniffs\Classes\ClassDeclarationSniff as PearClassDeclarationSniff;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class ClassDeclarationSniff extends PearClassDeclarationSniff
 {
 
     /**
@@ -43,7 +45,7 @@ class FuelPHP_Sniffs_Classes_ClassDeclarationSniff extends PEAR_Sniffs_Classes_C
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         $errorData = array($tokens[$stackPtr]['content']);
@@ -56,7 +58,7 @@ class FuelPHP_Sniffs_Classes_ClassDeclarationSniff extends PEAR_Sniffs_Classes_C
         );
         if (preg_match('/^\{\s*\}$/', $body)) {
             if (preg_match('/\s/', $body)) {
-                $error = 'Opening and closing braces of an empty %s must be on 
+                $error = 'Opening and closing braces of an empty %s must be on
                     the same line as the definition, with no spaces between them.';
                 $phpcsFile->addError(
                     $error, $stackPtr, 'EmptyBodyBraces', $errorData
@@ -67,7 +69,7 @@ class FuelPHP_Sniffs_Classes_ClassDeclarationSniff extends PEAR_Sniffs_Classes_C
             parent::process($phpcsFile, $stackPtr);
             // check braces alignment
             if ($tokens[$openingBrace]['column'] !== $tokens[$closingBrace]['column']) {
-                $error = 'Closing braces must have the same indentation than 
+                $error = 'Closing braces must have the same indentation than
                     their respective opening one.';
                 $phpcsFile->addError(
                     $error, $closingBrace, 'BadClosingBraceIndentation', $errorData

--- a/Standards/FuelPHP/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/Standards/FuelPHP/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -28,7 +28,13 @@
  * @version   Release: 1.4.0
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class FuelPHP_Sniffs_ControlStructures_SwitchDeclarationSniff implements PHP_CodeSniffer_Sniff
+namespace FuelPHP\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class SwitchDeclarationSniff implements Sniff
 {
 
     /**
@@ -63,7 +69,7 @@ class FuelPHP_Sniffs_ControlStructures_SwitchDeclarationSniff implements PHP_Cod
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -202,7 +208,7 @@ class FuelPHP_Sniffs_ControlStructures_SwitchDeclarationSniff implements PHP_Cod
                                 continue;
                             }
 
-                            if (in_array($tokens[$i]['code'], PHP_CodeSniffer_Tokens::$emptyTokens) === false) {
+                            if (in_array($tokens[$i]['code'], Tokens::$emptyTokens) === false) {
                                 $foundContent = true;
                                 break;
                             }

--- a/Standards/FuelPHP/Sniffs/Formatting/BracesOnNewLineSniff.php
+++ b/Standards/FuelPHP/Sniffs/Formatting/BracesOnNewLineSniff.php
@@ -26,8 +26,12 @@
  * @version   Release: 1.0.0
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class FuelPHP_Sniffs_Formatting_BracesOnNewLineSniff 
-    implements PHP_CodeSniffer_Sniff
+namespace FuelPHP\Sniffs\Formatting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class BracesOnNewLineSniff implements Sniff
 {
 
     /**
@@ -54,7 +58,7 @@ class FuelPHP_Sniffs_Formatting_BracesOnNewLineSniff
             T_FOR,
             T_FOREACH,
             T_WHILE,
-            T_SWITCH,            
+            T_SWITCH,
         );
     }
 
@@ -67,12 +71,12 @@ class FuelPHP_Sniffs_Formatting_BracesOnNewLineSniff
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         $registered = $this->register();
         // ensure we get one of the registered token
-        if (in_array($tokens[$stackPtr]['code'], $registered)) {            
+        if (in_array($tokens[$stackPtr]['code'], $registered)) {
             if (!isset($tokens[$stackPtr]['scope_opener'])
                     || !isset($tokens[$stackPtr]['scope_closer'])) {
                 return;
@@ -81,11 +85,11 @@ class FuelPHP_Sniffs_Formatting_BracesOnNewLineSniff
             $line   = $tokens[$stackPtr]['line'];
             $opener = $tokens[$stackPtr]['scope_opener'];
             $closer = $tokens[$stackPtr]['scope_closer'];
-            
+
             // check opening braces on next line
             if ($tokens[$opener]['line'] !== ($line + 1)) {
                 $error = 'Opening brace must be on next line from its condition';
-                $phpcsFile->addError($error, $stackPtr, 'OpeningBraceOnNextLine');                
+                $phpcsFile->addError($error, $stackPtr, 'OpeningBraceOnNextLine');
             }
             // check correct indentation
             if ($tokens[$opener]['column'] !== $column) {
@@ -100,7 +104,7 @@ class FuelPHP_Sniffs_Formatting_BracesOnNewLineSniff
             // check closing braces on their own lines
             $alone   = true;
             $current = $closer-1;
-            while ($tokens[$current]['line'] === $tokens[$closer]['line'] 
+            while ($tokens[$current]['line'] === $tokens[$closer]['line']
                     && $alone
                     && $current > $opener) {
                 $alone = $tokens[$current]['code'] === T_WHITESPACE;
@@ -108,7 +112,7 @@ class FuelPHP_Sniffs_Formatting_BracesOnNewLineSniff
             }
             if ($alone !== true) {
                 $error = 'Closing brace must be on next line from the content before';
-                $phpcsFile->addError($error, $stackPtr, 'ClosingBraceOnNextLine');               
+                $phpcsFile->addError($error, $stackPtr, 'ClosingBraceOnNextLine');
             }
              // check correct indentation
             if ($tokens[$closer]['column'] !== $column) {
@@ -120,6 +124,6 @@ class FuelPHP_Sniffs_Formatting_BracesOnNewLineSniff
                 $error = 'Closing brace must be followed by EOL char';
                 $phpcsFile->addError($error, $stackPtr, 'ClosingBraceFollowedByEOL');
             }
-        }        
+        }
     }
 }

--- a/Standards/FuelPHP/Sniffs/NamingConventions/ConciseUnderscoredVariableNameSniff.php
+++ b/Standards/FuelPHP/Sniffs/NamingConventions/ConciseUnderscoredVariableNameSniff.php
@@ -12,12 +12,6 @@
  * @license   http://opensource.org/licenses/MIT MIT License
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-if (class_exists('FuelPHP_Sniffs_NamingConventions_UnderscoredWithScopeFunctionNameSniff', true) === false) {
-    throw new PHP_CodeSniffer_Exception(
-        'Class FuelPHP_Sniffs_NamingConventions_UnderscoredWithScopeFunctionNameSniff not found'
-    );
-}
-
 /**
  * FuelPHP_Sniffs_NamingConventions_ConciseUnderscoredVariableNameSniff.
  *
@@ -31,8 +25,13 @@ if (class_exists('FuelPHP_Sniffs_NamingConventions_UnderscoredWithScopeFunctionN
  * @version   Release: 1.0.0
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class FuelPHP_Sniffs_NamingConventions_ConciseUnderscoredVariableNameSniff 
-    implements PHP_CodeSniffer_Sniff
+namespace FuelPHP\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use FuelPHP\Sniffs\NamingConventions\UnderscoredWithScopeFunctionNameSniff;
+
+class ConciseUnderscoredVariableNameSniff implements Sniff
 {
 
     /**
@@ -48,8 +47,8 @@ class FuelPHP_Sniffs_NamingConventions_ConciseUnderscoredVariableNameSniff
 
     /**
      * variable name length limit
-     * 
-     * @var integer 
+     *
+     * @var integer
      */
     public $maxlength = 30;
 
@@ -72,7 +71,7 @@ class FuelPHP_Sniffs_NamingConventions_ConciseUnderscoredVariableNameSniff
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -86,7 +85,7 @@ class FuelPHP_Sniffs_NamingConventions_ConciseUnderscoredVariableNameSniff
         $name = $tokens[$stackPtr]['content'];
         $ignore_names = ['$_SERVER', '$_POST', '$_GET', '$_REQUEST', '$_COOKIE'];
 
-        if (FuelPHP_Sniffs_NamingConventions_UnderscoredWithScopeFunctionNameSniff::isUnderscoreName($name) === false && ! in_array($name, $ignore_names)) {
+        if (UnderscoredWithScopeFunctionNameSniff::isUnderscoreName($name) === false && ! in_array($name, $ignore_names)) {
             $error = 'Variable name "%s" does not use underscore format.
                 Upper case forbidden.';
             $phpcsFile->addError($error, $stackPtr, 'NotUnderscore');

--- a/Standards/FuelPHP/Sniffs/NamingConventions/LowerCaseFileNameSniff.php
+++ b/Standards/FuelPHP/Sniffs/NamingConventions/LowerCaseFileNameSniff.php
@@ -26,8 +26,12 @@
  * @version   Release: 1.0.0
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class FuelPHP_Sniffs_NamingConventions_LowerCaseFileNameSniff 
-    implements PHP_CodeSniffer_Sniff
+namespace FuelPHP\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class LowerCaseFileNameSniff  implements Sniff
 {
 
     /**
@@ -43,7 +47,7 @@ class FuelPHP_Sniffs_NamingConventions_LowerCaseFileNameSniff
 
     /**
      * last file name checked
-     * 
+     *
      * @var string
      */
     protected static $lastfile = '';
@@ -67,7 +71,7 @@ class FuelPHP_Sniffs_NamingConventions_LowerCaseFileNameSniff
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $filename = $phpcsFile->getFilename();
         if (static::$lastfile === $filename) {

--- a/Standards/FuelPHP/Sniffs/NamingConventions/UnderscoredWithScopeFunctionNameSniff.php
+++ b/Standards/FuelPHP/Sniffs/NamingConventions/UnderscoredWithScopeFunctionNameSniff.php
@@ -236,7 +236,7 @@ class UnderscoredWithScopeFunctionNameSniff extends AbstractVariableSniff
                 continue;
             }
 
-            if ($bit{0} !== strtolower($bit{0})) {
+            if ($bit[0] !== strtolower($bit[0])) {
                 $validName = false;
                 break;
             }

--- a/Standards/FuelPHP/Sniffs/NamingConventions/UnderscoredWithScopeFunctionNameSniff.php
+++ b/Standards/FuelPHP/Sniffs/NamingConventions/UnderscoredWithScopeFunctionNameSniff.php
@@ -12,11 +12,6 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-if (class_exists('PHP_CodeSniffer_Standards_AbstractScopeSniff', true) === false) {
-    throw new PHP_CodeSniffer_Exception(
-        'Class PHP_CodeSniffer_Standards_AbstractScopeSniff not found'
-    );
-}
 
 /**
  * FuelPHP_Sniffs_NamingConventions_UnderscoredWithScopeFunctionNameSniff.
@@ -31,8 +26,13 @@ if (class_exists('PHP_CodeSniffer_Standards_AbstractScopeSniff', true) === false
  * @version   Release: 1.0.0
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class FuelPHP_Sniffs_NamingConventions_UnderscoredWithScopeFunctionNameSniff
-    extends PHP_CodeSniffer_Standards_AbstractScopeSniff
+
+namespace FuelPHP\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
+use PHP_CodeSniffer\Files\File;
+
+class UnderscoredWithScopeFunctionNameSniff extends AbstractVariableSniff
 {
     /**
      * A list of all PHP magic methods.
@@ -56,7 +56,7 @@ class FuelPHP_Sniffs_NamingConventions_UnderscoredWithScopeFunctionNameSniff
                                'invoke',
                                'call',
                               );
-        
+
     /**
      * A list of all PHP magic functions.
      *
@@ -70,11 +70,15 @@ class FuelPHP_Sniffs_NamingConventions_UnderscoredWithScopeFunctionNameSniff
     public function __construct()
     {
         parent::__construct(
-            array(T_CLASS, T_INTERFACE, T_TRAIT), 
-            array(T_FUNCTION), 
+            array(T_CLASS, T_INTERFACE, T_TRAIT),
+            array(T_FUNCTION),
             true
         );
     }//end __construct()
+
+    protected function processMemberVar(File $phpcsFile, $stackPtr){}
+    protected function processVariable(File $phpcsFile, $stackPtr){}
+    protected function processVariableInString(File $phpcsFile, $stackPtr){}
 
     /**
      * Processes the tokens within the scope.
@@ -86,78 +90,78 @@ class FuelPHP_Sniffs_NamingConventions_UnderscoredWithScopeFunctionNameSniff
      *
      * @return void
      */
-    protected function processTokenWithinScope(
-        PHP_CodeSniffer_File $phpcsFile, 
-        $stackPtr, 
-        $currScope
-    ) {
-        $methodName = $phpcsFile->getDeclarationName($stackPtr);
-        if ($methodName === null) {
-            // Ignore closures.
-            return;
-        }
+    // protected function processTokenWithinScope(
+    //     PHP_CodeSniffer_File $phpcsFile,
+    //     $stackPtr,
+    //     $currScope
+    // ) {
+    //     $methodName = $phpcsFile->getDeclarationName($stackPtr);
+    //     if ($methodName === null) {
+    //         // Ignore closures.
+    //         return;
+    //     }
 
-        $className = $phpcsFile->getDeclarationName($currScope);
-        $errorData = array($className.'::'.$methodName);
+    //     $className = $phpcsFile->getDeclarationName($currScope);
+    //     $errorData = array($className.'::'.$methodName);
 
-        // Is this a magic method. i.e., is prefixed with "__" ?
-        if (preg_match('|^__|', $methodName) !== 0) {
-            $magicPart = substr($methodName, 2);
-            if (in_array($magicPart, $this->magicMethods) === false) {
-                 $error = 'Method name "%s" is invalid; 
-                     only PHP magic methods should be prefixed with a 
-                     double underscore';
-                 $phpcsFile->addError(
-                     $error,
-                     $stackPtr,
-                     'MethodDoubleUnderscore', 
-                     $errorData
-                 );
-            }
+    //     // Is this a magic method. i.e., is prefixed with "__" ?
+    //     if (preg_match('|^__|', $methodName) !== 0) {
+    //         $magicPart = substr($methodName, 2);
+    //         if (in_array($magicPart, $this->magicMethods) === false) {
+    //              $error = 'Method name "%s" is invalid;
+    //                  only PHP magic methods should be prefixed with a
+    //                  double underscore';
+    //              $phpcsFile->addError(
+    //                  $error,
+    //                  $stackPtr,
+    //                  'MethodDoubleUnderscore',
+    //                  $errorData
+    //              );
+    //         }
 
-            return;
-        }
+    //         return;
+    //     }
 
-        // PHP4 constructors are allowed to break our rules.
-        if ($methodName === $className) {
-            return;
-        }
+    //     // PHP4 constructors are allowed to break our rules.
+    //     if ($methodName === $className) {
+    //         return;
+    //     }
 
-        // PHP4 destructors are allowed to break our rules.
-        if ($methodName === '_'.$className) {
-            return;
-        }		
+    //     // PHP4 destructors are allowed to break our rules.
+    //     if ($methodName === '_'.$className) {
+    //         return;
+    //     }
 
-        $methodProps = $phpcsFile->getMethodProperties($stackPtr);
-        if ($methodProps['scope_specified'] !== true) {
-            $error = 'Method visibility scope must be specified for "%s".';
-            $phpcsFile->addError($error, $stackPtr, 'VisibilityScope', $errorData);
-        }
+    //     $methodProps = $phpcsFile->getMethodProperties($stackPtr);
+    //     if ($methodProps['scope_specified'] !== true) {
+    //         $error = 'Method visibility scope must be specified for "%s".';
+    //         $phpcsFile->addError($error, $stackPtr, 'VisibilityScope', $errorData);
+    //     }
 
-        // check underscore format and visibility scope
-        if (static::isUnderscoreName($methodName) === false) {
-            if ($methodProps['scope_specified'] === true) {
-                $error = '%s method name "%s" does not use underscore format. 
-                    Upper case forbidden.';
-                $data  = array(
-                          ucfirst($methodProps['scope']),
-                          $errorData[0],
-                         );
-                $phpcsFile->addError($error, $stackPtr, 'ScopeNotUnderscore', $data);
-            } else {
-                $error = 'Method name "%s" does not use underscore format.
-                     Upper case forbidden.';
-                $phpcsFile->addError(
-                    $error,
-                    $stackPtr,
-                    'NotUnderscore',
-                    $errorData
-                );
-            }
-            return;
-        }
+    //     // check underscore format and visibility scope
+    //     if (static::isUnderscoreName($methodName) === false) {
+    //         if ($methodProps['scope_specified'] === true) {
+    //             $error = '%s method name "%s" does not use underscore format.
+    //                 Upper case forbidden.';
+    //             $data  = array(
+    //                       ucfirst($methodProps['scope']),
+    //                       $errorData[0],
+    //                      );
+    //             $phpcsFile->addError($error, $stackPtr, 'ScopeNotUnderscore', $data);
+    //         } else {
+    //             $error = 'Method name "%s" does not use underscore format.
+    //                  Upper case forbidden.';
+    //             $phpcsFile->addError(
+    //                 $error,
+    //                 $stackPtr,
+    //                 'NotUnderscore',
+    //                 $errorData
+    //             );
+    //         }
+    //         return;
+    //     }
 
-    }//end processTokenWithinScope()
+    // }//end processTokenWithinScope()
 
 
     /**
@@ -169,42 +173,42 @@ class FuelPHP_Sniffs_NamingConventions_UnderscoredWithScopeFunctionNameSniff
      *
      * @return void
      */
-    protected function processTokenOutsideScope(
-        PHP_CodeSniffer_File $phpcsFile, $stackPtr
-    ) {
-        $functionName = $phpcsFile->getDeclarationName($stackPtr);
-        if ($functionName === null) {
-            // Ignore closures.
-            return;
-        }
+    // protected function processTokenOutsideScope(
+    //     PHP_CodeSniffer_File $phpcsFile, $stackPtr
+    // ) {
+    //     $functionName = $phpcsFile->getDeclarationName($stackPtr);
+    //     if ($functionName === null) {
+    //         // Ignore closures.
+    //         return;
+    //     }
 
-        $errorData = array($functionName);
+    //     $errorData = array($functionName);
 
-        // Is this a magic function. IE. is prefixed with "__".
-        if (preg_match('|^__|', $functionName) !== 0) {
-            $magicPart = substr($functionName, 2);
-            if (in_array($magicPart, $this->magicFunctions) === false) {
-                 $error = 'Function name "%s" is invalid; only PHP magic methods 
-                     should be prefixed with a double underscore';
-                 $phpcsFile->addError(
-                     $error,
-                     $stackPtr,
-                     'FunctionDoubleUnderscore',
-                     $errorData
-                 );
-            }
+    //     // Is this a magic function. IE. is prefixed with "__".
+    //     if (preg_match('|^__|', $functionName) !== 0) {
+    //         $magicPart = substr($functionName, 2);
+    //         if (in_array($magicPart, $this->magicFunctions) === false) {
+    //              $error = 'Function name "%s" is invalid; only PHP magic methods
+    //                  should be prefixed with a double underscore';
+    //              $phpcsFile->addError(
+    //                  $error,
+    //                  $stackPtr,
+    //                  'FunctionDoubleUnderscore',
+    //                  $errorData
+    //              );
+    //         }
 
-            return;
-        }
+    //         return;
+    //     }
 
-        if (static::isUnderscoreName($functionName) === false) {
-            $error = 'Function name "%s" does not use underscore format. 
-                Upper case forbidden.';
-            $phpcsFile->addError($error, $stackPtr, 'NotUnderscore', $errorData);
-        }
+    //     if (static::isUnderscoreName($functionName) === false) {
+    //         $error = 'Function name "%s" does not use underscore format.
+    //             Upper case forbidden.';
+    //         $phpcsFile->addError($error, $stackPtr, 'NotUnderscore', $errorData);
+    //     }
 
 
-    }//end processTokenOutsideScope()
+    // }//end processTokenOutsideScope()
 
     /**
      * Returns true if the specified string is in the underscore caps format.

--- a/Standards/FuelPHP/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/Standards/FuelPHP/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -27,7 +27,12 @@
  * @version   Release: 1.4.0
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class FuelPHP_Sniffs_Strings_DoubleQuoteUsageSniff implements PHP_CodeSniffer_Sniff
+namespace FuelPHP\Sniffs\Strings;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class DoubleQuoteUsageSniff implements Sniff
 {
 
 
@@ -55,7 +60,7 @@ class FuelPHP_Sniffs_Strings_DoubleQuoteUsageSniff implements PHP_CodeSniffer_Sn
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Standards/FuelPHP/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/Standards/FuelPHP/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -27,7 +27,12 @@
  * @version   Release: 1.4.0
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class FuelPHP_Sniffs_WhiteSpace_ControlStructureSpacingSniff implements PHP_CodeSniffer_Sniff
+namespace FuelPHP\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class ControlStructureSpacingSniff implements Sniff
 {
 
     /**
@@ -72,7 +77,7 @@ class FuelPHP_Sniffs_WhiteSpace_ControlStructureSpacingSniff implements PHP_Code
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Standards/FuelPHP/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
+++ b/Standards/FuelPHP/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
@@ -26,8 +26,12 @@
  * @version   Release: 1.0.0
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class FuelPHP_Sniffs_WhiteSpace_DisallowSpaceIndentSniff 
-    implements PHP_CodeSniffer_Sniff
+namespace FuelPHP\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class DisallowSpaceIndentSniff implements Sniff
 {
 
     /**
@@ -60,7 +64,7 @@ class FuelPHP_Sniffs_WhiteSpace_DisallowSpaceIndentSniff
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Standards/FuelPHP/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php
+++ b/Standards/FuelPHP/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php
@@ -26,8 +26,12 @@
  * @version   Release: 1.0.0
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class FuelPHP_Sniffs_WhiteSpace_IncrementDecrementSpacingSniff 
-    implements PHP_CodeSniffer_Sniff
+namespace FuelPHP\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class IncrementDecrementSpacingSniff implements Sniff
 {
 
     /**
@@ -50,7 +54,7 @@ class FuelPHP_Sniffs_WhiteSpace_IncrementDecrementSpacingSniff
         return array(
             T_INC,
             T_DEC,
-            T_VARIABLE,            
+            T_VARIABLE,
         );
     }
 
@@ -63,17 +67,17 @@ class FuelPHP_Sniffs_WhiteSpace_IncrementDecrementSpacingSniff
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-        if ($tokens[$stackPtr]['code'] === T_INC 
+        if ($tokens[$stackPtr]['code'] === T_INC
             || $tokens[$stackPtr]['code'] === T_DEC
         ) {
-            if ($tokens[$stackPtr - 1]['code'] !== T_VARIABLE 
+            if ($tokens[$stackPtr - 1]['code'] !== T_VARIABLE
                 && $tokens[$stackPtr + 1]['code'] !== T_VARIABLE
                 && $tokens[$stackPtr + 1]['code'] !== T_SEMICOLON
             ) {
-                $error = 'Increment and decrement operators need to be close to 
+                $error = 'Increment and decrement operators need to be close to
                     their variable. No inside space is allowed.';
                 $phpcsFile->addError($error, $stackPtr, 'NoInsideSpaceAllowed');
             }

--- a/Standards/FuelPHP/Sniffs/WhiteSpace/NotOperatorSpacingSniff.php
+++ b/Standards/FuelPHP/Sniffs/WhiteSpace/NotOperatorSpacingSniff.php
@@ -26,8 +26,12 @@
  * @version   Release: 1.0.0
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class FuelPHP_Sniffs_WhiteSpace_NotOperatorSpacingSniff 
-    implements PHP_CodeSniffer_Sniff
+namespace FuelPHP\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class NotOperatorSpacingSniff implements Sniff
 {
 
     /**
@@ -61,7 +65,7 @@ class FuelPHP_Sniffs_WhiteSpace_NotOperatorSpacingSniff
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         if ($tokens[$stackPtr]['code'] === T_BOOLEAN_NOT)
@@ -76,6 +80,6 @@ class FuelPHP_Sniffs_WhiteSpace_NotOperatorSpacingSniff
                 $error = 'A space need to be set after the ! operator.';
                 $phpcsFile->addError($error, $stackPtr, 'SpaceAfterNotOperator');
             }
-        }        
+        }
     }
 }


### PR DESCRIPTION
php 8 no longer supports accessing strings/arrays using curly brackets `str{0}`, which was being used in one of the code sniffer files here. 

This fixes that.

Also, it appears we never merged those updates into master, so I'm just going to target this at master.  Either way, it'll need a tag and a few updates over on Materia to be able to get the pre-commit checks to go green once it moves to php 8.  https://github.com/ucfopen/Materia/pull/1407

